### PR TITLE
use protobufjs library instead of protobuf

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git://github.com/perezd/riemann-nodejs-client.git"
   },
   "dependencies" :{
-    "protobuf" : "0.8.6"
+    "protobufjs": "3.8.2"
   },
   "devDependencies" : {
     "mocha" : "*",

--- a/riemann/client.js
+++ b/riemann/client.js
@@ -47,7 +47,6 @@ function _defaultValues(payload) {
   if (!payload.time)  { payload.time = new Date().getTime()/1000; }
   if (typeof payload.metric !== "undefined" && payload.metric !== null) {
     payload.metric_f = payload.metric;
-    delete payload.metric;
   }
   return payload;
 }

--- a/riemann/client.js
+++ b/riemann/client.js
@@ -46,7 +46,8 @@ function _defaultValues(payload) {
   if (!payload.host)  { payload.host = hostname; }
   if (!payload.time)  { payload.time = new Date().getTime()/1000; }
   if (typeof payload.metric !== "undefined" && payload.metric !== null) {
-    payload.metricF = payload.metric;
+    payload.metric_f = payload.metric;
+    delete payload.metric;
   }
   return payload;
 }

--- a/riemann/serializer.js
+++ b/riemann/serializer.js
@@ -11,37 +11,24 @@ function _deserialize(type, value) {
   return buf[type].decode(value);
 }
 
-/* serialization support for all
-   known Riemann protobuf types. */
-
-exports.serializeEvent = function(event) {
-  return _serialize('Event', event);
-};
-
-exports.deserializeEvent = function(event) {
-  return _deserialize('Event', event);
-};
+/* protobuf has a very strict type system, so ensure that only the
+   whitelisted attributes get passed through */
+var event_fields = [ 'time', 'state', 'service', 'host', 'description', 'tags', 'ttl', 'attributes', 'metric_f' ];
+function _cleanEvent(event) {
+  var serializableEvent = {};
+  for (var i = 0; i < event_fields.length; i++) {
+    if (event[event_fields[i]] !== undefined && event[event_fields[i]] !== null) {
+      serializableEvent[event_fields[i]] = event[event_fields[i]];
+    }
+  }
+  return serializableEvent;
+}
 
 exports.serializeMessage = function(message) {
+  message.events = (message.events || []).map(_cleanEvent);
   return _serialize('Msg', message);
 };
 
 exports.deserializeMessage = function(message) {
   return _deserialize('Msg', message);
-};
-
-exports.serializeQuery = function(query) {
-  return _serialize('Query', query);
-};
-
-exports.deserializeQuery = function(query) {
-  return _deserialize('Query', query);
-};
-
-exports.serializeState = function(state) {
-  return _serialize('State', state);
-};
-
-exports.deserializeState = function(state) {
-  return _deserialize('State', state);
 };

--- a/riemann/serializer.js
+++ b/riemann/serializer.js
@@ -1,18 +1,14 @@
 /* initialize our protobuf schema,
    and cache it in memory. */
-var riemannSchema;
-if (!riemannSchema) {
-  var Schema    = require('protobuf').Schema;
-  var readFile  = require('fs').readFileSync;
-  riemannSchema = new Schema(readFile(__dirname+'/proto/proto.desc'));
-}
+var protobuf = require('protobufjs');
+var buf = protobuf.loadProtoFile(__dirname + '/proto/proto.proto').build();
 
 function _serialize(type, value) {
-  return riemannSchema[type].serialize(value);
+  return new buf[type](value).encode().toBuffer();
 }
 
 function _deserialize(type, value) {
-  return riemannSchema[type].parse(value);
+  return buf[type].decode(value);
 }
 
 /* serialization support for all


### PR DESCRIPTION
No particular reason to do one or the other, but I use protobufjs instead of protobuf in other places as well, and I don't really want to have two protobuf encoding/decoding libraries :-)

There is an argument to be made for fewer OS-level dependencies, though.