### PR TITLE
Prevent too many outstanding messages from being sent at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,30 @@ client.on('disconnect', function(){
 client.disconnect();
 ```
 
+## Backpressure
+
+Riemann over TCP acknowledges every message, thus providing an effective way to prevent overloading the system. The Riemann client has a built-in device to prevent too many messages from being sent without acknowledgement at once. Just specify a `maxOutstandingMessages` in `createClient`, and if the number of in-flight messages exceeds that number, `client.send` will throw a `TooManyMessagesError`. Be sure to use the TCP transport, as this is the only way the client receives message acknowledgements.
+
+You can also read `client.outstandingMessages` if you want to see the number of in-flight messages at any given time.
+
+```js
+var client = require('riemann').createClient({
+  host: 'some.riemann.server',
+  port: 5555,
+  maxOutstandingMessages: 1000
+});
+
+try {
+  client.send(client.Event({
+    service: 'buffet_plates',
+    metric:  252.2,
+    tags:    ['nonblocking']
+  }), client.tcp);
+} catch (e) {
+  console.log('Riemann is overloaded!');
+}
+```
+
 
 ## Contributing
 

--- a/riemann/client.js
+++ b/riemann/client.js
@@ -101,7 +101,7 @@ function Client(options, onConnect) {
   this.udp.socket.on('error', function(error) { self.emit('error', error); });
 
   this.tcp.onMessage(function(message) {
-    self.outstandingMessages--;
+    if (self.outstandingMessages > 0) { self.outstandingMessages--; }
     self.emit('data', Serializer.deserializeMessage(message));
   });
 
@@ -147,10 +147,10 @@ Client.prototype.send = function(payload, transport) {
     transport = this.udp;
   }
   if (transport === this.tcp) {
-    this.outstandingMessages++;
     if (this.maxOutstandingMessages && this.outstandingMessages > this.maxOutstandingMessages) {
       throw new TooManyMessagesError(this.outstandingMessages);
     }
+    this.outstandingMessages++;
   }
   payload.apply(transport);
 };


### PR DESCRIPTION
Riemann offers a form of backpressure, by acknowledging every message it receives. This pull request adds an optional mechanism to cap the number of in-flight messages so as to be sure not to overload Riemann.
