### PR TITLE
Moved from `protobuf` to `protocol-buffers` to allow installation on Node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,24 @@
 {
-  "name" : "riemann",
-  "version" : "0.4.3",
-  "description" : "node.js client for Riemann, supports hybrid UDP/TCP connections.",
+  "name": "riemann",
+  "version": "0.4.3",
+  "description": "node.js client for Riemann, supports hybrid UDP/TCP connections.",
   "author": {
     "Derek Perez": "derek@derekperez.com",
     "Julien Boeuf": "julien@boeuf.org"
   },
   "main": "riemann",
-  "engines": { "node": "> 0.6.0" },
+  "engines": {
+    "node": "> 0.6.0"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/perezd/riemann-nodejs-client.git"
   },
-  "dependencies" :{
-    "protobuf" : "0.8.6"
+  "dependencies": {
+    "protocol-buffers": "^3.1.2"
   },
-  "devDependencies" : {
-    "mocha" : "*",
+  "devDependencies": {
+    "mocha": "*",
     "jshint": "*"
   },
   "scripts": {

--- a/riemann/serializer.js
+++ b/riemann/serializer.js
@@ -2,17 +2,17 @@
    and cache it in memory. */
 var riemannSchema;
 if (!riemannSchema) {
-  var Schema    = require('protobuf').Schema;
+  var protobuf  = require('protocol-buffers');
   var readFile  = require('fs').readFileSync;
-  riemannSchema = new Schema(readFile(__dirname+'/proto/proto.desc'));
+  riemannSchema = protobuf(readFile(__dirname+'/proto/proto.proto'));
 }
 
 function _serialize(type, value) {
-  return riemannSchema[type].serialize(value);
+  return riemannSchema[type].encode(value);
 }
 
 function _deserialize(type, value) {
-  return riemannSchema[type].parse(value);
+  return riemannSchema[type].decode(value);
 }
 
 /* serialization support for all

--- a/test/basic_tests.js
+++ b/test/basic_tests.js
@@ -13,7 +13,7 @@ test("should connect to server", function(done) {
 
 var server_down;
 test("should fire error event", function(done) {
-  server_down = require('riemann').createClient({port: 66500});
+  server_down = require('riemann').createClient({port: 64500});
   server_down.on('error', function(e) {
     assert(e instanceof Error);
     done();


### PR DESCRIPTION
Should fix #12.

I have zero Riemann knowledge, but the test cases pass on both Node 0.10 and Node 0.12 (to get them working on 0.12 I had to lower the client port number in the tests, I don't know if this is acceptable but Node will throw a `RangeError` otherwise).

The `package.json` reformatting is due to using `npm install --save`, hope that's okay.