### PR TITLE
Reverted back to `protobuf` module (latest version).

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git://github.com/perezd/riemann-nodejs-client.git"
   },
   "dependencies": {
-    "protocol-buffers": "^3.1.2"
+    "protobuf": "^0.11.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/riemann/serializer.js
+++ b/riemann/serializer.js
@@ -2,17 +2,17 @@
    and cache it in memory. */
 var riemannSchema;
 if (!riemannSchema) {
-  var protobuf  = require('protocol-buffers');
+  var Schema    = require('protobuf').Schema;
   var readFile  = require('fs').readFileSync;
-  riemannSchema = protobuf(readFile(__dirname+'/proto/proto.proto'));
+  riemannSchema = new Schema(readFile(__dirname+'/proto/proto.desc'));
 }
 
 function _serialize(type, value) {
-  return riemannSchema[type].encode(value);
+  return riemannSchema[type].serialize(value);
 }
 
 function _deserialize(type, value) {
-  return riemannSchema[type].decode(value);
+  return riemannSchema[type].parse(value);
 }
 
 /* serialization support for all

--- a/test/basic_tests.js
+++ b/test/basic_tests.js
@@ -67,7 +67,8 @@ test("should send an event with custom attributes as tcp", function(done) {
     client.send(client.Event({
       service : 'hello_tcp_'+i,
       attributes: [{key: "session", value: "123-456-789"},
-                   {key: "metric_type", value: "random_number"}],
+                   {key: "metric_type", value: "random_number"}
+                   ],
       metric  : Math.random(100)*100,
       tags    : ['bar'] }), client.tcp);
   }
@@ -122,3 +123,22 @@ test("should disconnect from server", function(done) {
   client.disconnect();
 });
 
+suite("serialization", function() {
+  var serializer = require('../riemann/serializer');
+  var eventObj   = {
+    service    : "hello_tcp_123",
+    ttl        : "" + Math.random(100)*100,    // should be a float
+    attributes : [ {key: "foo", value: 123} ], // value should be a string
+  };
+
+  test("should not throw for type mismatch", function() {
+    serializer.serializeEvent(eventObj);
+  });
+
+  test("should cast to proper type", function() {
+    var event = serializer.deserializeEvent(serializer.serializeEvent(eventObj));
+    assert(typeof event.ttl === 'number');
+    assert(typeof event.attributes[0].value === 'string');
+  });
+
+});


### PR DESCRIPTION
The module that replaced it (`protocol-buffers`) is more strict and will throw when input types don't match the declared field types in the protobuf spec (whereas `protobuf` does implicit type casting), hence breaking backward compatibility.

This should fix #16 (although it will also revert back to requiring compilation during installation).

The version of `protobuf` being used, `0.11.0`, is the latest in the NPM repository, even though the [Github repository](https://github.com/chrisdew/protobuf) states that the latest version is [`0.8.7`](https://github.com/chrisdew/protobuf/blob/master/package.json#L3), which is a bit confusing.