### PR TITLE
Switch to better-maintained node-protobuf module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+sudo: true
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+    - libprotobuf-dev
+before_install:
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+  - curl -O https://aphyr.com/riemann/riemann_0.2.10_all.deb
+  - sudo dpkg --install riemann_0.2.10_all.deb
+  - sudo service riemann start
+script:
+  - npm run lint
+  - npm test

--- a/README.md
+++ b/README.md
@@ -2,12 +2,36 @@
 
 because you should be monitoring all of those [non-blocking buffet plates.](http://www.infinitelooper.com/?v=-sfZqL4Plxc&p=n#/242;267)
 
+## Prerequisites
+
+Riemann uses [Google Protocol Buffers](https://github.com/google/protobuf),
+so please make sure it's installed beforehand.
+
+### Ubuntu/Debian via apt
+
+```sh
+apt-get install libprotobuf-dev
+```
+
+### RHEL/Centos via yum
+
+```sh
+yum install protobuf-devel
+```
+
+### Mac OS via homebrew
+
+```sh
+brew install protobuf
+```
+
+### Windows
+
+https://github.com/fuwaneko/node-protobuf#windows
 
 ## Installation
 
-Riemann uses [Google Protocol Buffers](http://code.google.com/p/protobuf/), so make sure thats installed beforehand, and available on your `PATH`.
-
-```
+```sh
 npm install riemann
 ```
 
@@ -16,12 +40,12 @@ npm install riemann
 first things first, we'll want to establish a new client:
 
 ```js
-var client = require('riemann').createClient({ 
-  host: 'some.riemann.server', 
-  port: 5555 
+var client = require('riemann').createClient({
+  host: 'some.riemann.server',
+  port: 5555
 });
 
-client.on('connect', function() { 
+client.on('connect', function() {
   console.log('connected!');
 });
 ```
@@ -41,7 +65,7 @@ client.send(client.Event({
 If you wanted to send that message over TCP and receive an acknowledgement, you can specify the transport, explicitly:
 
 ```js
-client.on('data', function(ack) { 
+client.on('data', function(ack) {
   console.log('got it!');
 });
 
@@ -67,7 +91,7 @@ client.send(client.Event({
 When you're done monitoring, disconnect:
 
 ```js
-client.on('disconnect', function(){ 
+client.on('disconnect', function(){
   console.log('disconnected!');
 });
 client.disconnect();

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "riemann",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "node.js client for Riemann, supports hybrid UDP/TCP connections.",
   "author": {
     "Derek Perez": "derek@derekperez.com",
     "Julien Boeuf": "julien@boeuf.org"
   },
+  "contributors": [
+    "Lovell Fuller <npm@lovell.info>"
+  ],
   "main": "riemann",
   "engines": {
     "node": "> 0.6.0"
@@ -15,7 +18,7 @@
     "url": "git://github.com/perezd/riemann-nodejs-client.git"
   },
   "dependencies": {
-    "protobuf": "^0.11.0"
+    "node-protobuf": "^1.2.9"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riemann",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "node.js client for Riemann, supports hybrid UDP/TCP connections.",
   "author": {
     "Derek Perez": "derek@derekperez.com",

--- a/riemann/serializer.js
+++ b/riemann/serializer.js
@@ -2,17 +2,17 @@
    and cache it in memory. */
 var riemannSchema;
 if (!riemannSchema) {
-  var Schema    = require('protobuf').Schema;
+  var Schema    = require('node-protobuf');
   var readFile  = require('fs').readFileSync;
   riemannSchema = new Schema(readFile(__dirname+'/proto/proto.desc'));
 }
 
 function _serialize(type, value) {
-  return riemannSchema[type].serialize(value);
+  return riemannSchema.serialize(value, type);
 }
 
 function _deserialize(type, value) {
-  return riemannSchema[type].parse(value);
+  return riemannSchema.parse(value, type);
 }
 
 /* serialization support for all


### PR DESCRIPTION
As discussed in #7, plus I've added installation instructions for the common package managers.

I've made a minor version bump for now, but we may want to do a major version bump for this.

I've also taken the liberty of creating a Travis CI config to install Riemann and run the tests, e.g. https://travis-ci.org/lovell/riemann-nodejs-client/builds/83315017