### PR TITLE
Ensure 'metric' is moved to 'metric_f'

### DIFF
--- a/riemann/client.js
+++ b/riemann/client.js
@@ -46,7 +46,8 @@ function _defaultValues(payload) {
   if (!payload.host)  { payload.host = hostname; }
   if (!payload.time)  { payload.time = new Date().getTime()/1000; }
   if (typeof payload.metric !== "undefined" && payload.metric !== null) {
-    payload.metricF = payload.metric;
+    payload.metric_f = payload.metric;
+    delete payload.metric;
   }
   return payload;
 }

--- a/test/basic_tests.js
+++ b/test/basic_tests.js
@@ -20,6 +20,26 @@ test("should fire error event", function(done) {
   });
 });
 
+test("should convert from metric to metric_f", function(done) {
+  var value = Math.random(100)*100;
+  // Generate 'message' with 'metric' attribute
+  client.Event({
+    metric: value
+  }).apply({
+    send: function(message) {
+      // Generate 'message_f' with 'metric_f' attribute
+      client.Event({
+        metric_f: value
+      }).apply({
+        send: function(message_f) {
+          // Verify message lengths match
+          assert.strictEqual(message.length, message_f.length);
+          done();
+        }
+      });
+    }
+  });
+});
 
 test("should send an event as udp", function(done) {
   client.send(client.Event({


### PR DESCRIPTION
Hello,

As discussed in #19, this PR adds a test for the scenario where the `metric` attribute is used as a proxy for Riemann's `metric_f` as well as the code change to satisfy it.