### PR TITLE
More control over dgram sending

### DIFF
--- a/riemann/client.js
+++ b/riemann/client.js
@@ -85,6 +85,9 @@ function Client(options, onConnect) {
   // proxy the TCP connect event.
   this.tcp.socket.on('connect', function() { self.emit('connect'); });
 
+  // proxy the UDP sent event.
+  this.udp.socket.on('sent', function() { self.emit('sent'); });
+
   // proxy errors from TCP and UDP
   this.tcp.socket.on('error', function(error) { self.emit('error', error); });
   this.udp.socket.on('error', function(error) { self.emit('error', error); });

--- a/riemann/socket.js
+++ b/riemann/socket.js
@@ -12,7 +12,19 @@ function udpSocket(options) {
 
 udpSocket.prototype.send = function(payload) {
   assert(Buffer.isBuffer(payload));
-  this.socket.send(payload, 0, payload.length, this.options.port, this.options.host);
+
+  var self = this;
+
+  function callback (err) {
+    if (err) {
+      self.socket.emit('error',err);
+    } else {
+      self.socket.emit('sent');
+    }
+  }
+
+  // callback usage lets us be aware not only of erroneous but successfull invocations as well
+  this.socket.send(payload, 0, payload.length, this.options.port, this.options.host, callback);
 };
 
 

--- a/riemann/socket.js
+++ b/riemann/socket.js
@@ -27,7 +27,7 @@ function tcpSocket(options) {
   // state machine for stream recv
   this._socketState     = 1;
   this._lenBufferOffset = 0;
-  this._lenBuffer       = new Buffer(4);
+  this._lenBuffer       = Buffer.alloc(4);
   this._payloadBuffer   = null;
   this._payloadOffset   = 0;
 }
@@ -52,7 +52,7 @@ tcpSocket.prototype.onMessage = function(emit) {
           if (chunk.length+self._lenBufferOffset >= 4) {
             chunkOffset += 4-self._lenBufferOffset;
             chunk.copy(self._lenBuffer, self._lenBufferOffset, 0, chunkOffset);
-            self._payloadBuffer = new Buffer(_getResponseLength(self._lenBuffer));
+            self._payloadBuffer = Buffer.alloc(_getResponseLength(self._lenBuffer));
             self._socketState = 2;
             self._lenBufferOffset = 0; // re-init
           } else {
@@ -84,7 +84,7 @@ tcpSocket.prototype.onMessage = function(emit) {
 tcpSocket.prototype.send = function(payload) {
   assert(Buffer.isBuffer(payload));
   var len = payload.length;
-  var packet = new Buffer(len + 4);
+  var packet = Buffer.alloc(len + 4);
   packet[0] = len >>> 24 & 0xFF;
   packet[1] = len >>> 16 & 0xFF;
   packet[2] = len >>> 8  & 0xFF;


### PR DESCRIPTION
I added 'callback' parameter to UDP socket.send to have full control over events emitted, including the case of successful dgram sending.
Also, I payed attention to Node's deprecation warning (https://nodejs.org/api/buffer.html#buffer_new_buffer_size) and fixed the cause.