### PR TITLE
Promisification refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ client.on('connect', function() {
 });
 ```
 
+Promise-based workflow is supported, too. Just pass 'returnPromise' flag set to _true_.
+All the Client's methods will return promises in that case.
+
+```js
+var client = await require('riemann').createClient({
+  host: 'some.riemann.server',
+  port: 5555,
+  returnPromise: true
+});
+```
+
 Just like [Riemann ruby client](https://github.com/aphyr/riemann-ruby-client), the client sends small events over UDP, by default. TCP is used for queries, and large events. There is no acknowledgement of UDP packets, but they are roughly an order of magnitude faster than TCP. We assume both TCP and UDP are listening to the same port.
 
 sending events is easy (see [list of valid event properties](http://aphyr.github.com/riemann/concepts.html)):
@@ -70,6 +81,14 @@ client.on('data', function(ack) {
 });
 
 client.send(client.Event({
+  service: 'buffet_plates',
+  metric:  252.2,
+  tags:    ['nonblocking']
+}), client.tcp);
+
+// ... or via promises
+
+var data = await client.send(client.Event({
   service: 'buffet_plates',
   metric:  252.2,
   tags:    ['nonblocking']
@@ -95,8 +114,11 @@ client.on('disconnect', function(){
   console.log('disconnected!');
 });
 client.disconnect();
-```
 
+// ... or just
+
+await client.disconnect();
+```
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riemann",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "node.js client for Riemann, supports hybrid UDP/TCP connections.",
   "author": {
     "Derek Perez": "derek@derekperez.com",

--- a/riemann/client.js
+++ b/riemann/client.js
@@ -15,6 +15,22 @@ var Serializer = require('./serializer');
 var Socket = require('./socket');
 
 
+/* allows to disconnect all those already
+   unnecessary 'data', 'sent' and 'error' handlers. */
+function _e2p(emitter, event, options) {
+  let p = e2p(emitter, event, options);
+
+  return p.then(() => {
+    p.cancel();
+    return p;
+  })
+  .catch(err => {
+    p.cancel();
+    throw err;
+  });
+}
+
+
 var MAX_UDP_BUFFER_SIZE = 16384;
 function _sendMessage(contents, transport) {
   var self = this;
@@ -41,7 +57,7 @@ function _sendMessage(contents, transport) {
 
     try {
       if (self.returnPromise) {
-        return e2p(self, t.promiseResolutionEvent);
+        return _e2p(self, t.promiseResolutionEvent);
       }
     }
     finally {
@@ -160,7 +176,7 @@ Client.prototype.send = function(payload, transport) {
 Client.prototype.disconnect = function(onDisconnect) {
   try {
     if (this.returnPromise) {
-      return e2p(this, 'disconnect');
+      return _e2p(this, 'disconnect');
     }
   }
   finally {

--- a/test/promisification_tests.js
+++ b/test/promisification_tests.js
@@ -3,103 +3,88 @@ const assert = require('assert');
 const host = (process.env.RIEMANN_HOST ? process.env.RIEMANN_HOST : '127.0.0.1');
 
 let client;
-test("[promisified client] should connect to server", function(done) {
-  require('riemann').createClient({host: host, returnPromise: true})
-    .then((c) => { client = c; done(); });
+test("[promisified client] should connect to server", async function() {
+  const createClient = require('riemann').createClient;
+
+  client = await createClient({host: host, returnPromise: true});
 });
 
-let server_down;
-test("[promisified client] should fire error event", function(done) {
-  server_down = require('riemann').createClient({host: host, port: 64500, returnPromise: true})
-    .catch((e) => {
-      assert(e instanceof Error);
-      done();
-    });
+test("[promisified client] should fire error event", async function() {
+  const createClient = require('riemann').createClient;
+
+  try {
+    await createClient({host: host, port: 64500, returnPromise: true});
+  }
+  catch(e) {
+    assert(e instanceof Error);
+  }
 });
 
-test("[promisified client] should send an event as udp", function(done) {
-  client.send(client.Event({
+test("[promisified client] should send an event as udp", async function() {
+  await client.send(client.Event({
     service : 'hello_udp',
     metric  : Math.random(100)*100,
-    tags    : ['bar'] }), client.udp).then(done);
+    tags    : ['bar'] }), client.udp);
 });
 
-test("[promisified client] should send an event as tcp", function(done) {
+test("[promisified client] should send an event as tcp", async function() {
   let counter = 10;
 
-  function listener(data) {
-    assert(data.ok);
-    if (--counter === 0) {
-      setTimeout(done, 100);
-    }
-  };
-
   for (let i = Number(counter); i >= 0; i--) {
-    client.send(client.Event({
+    const data = await client.send(client.Event({
       service : 'hello_tcp_'+i,
       metric  : Math.random(100)*100,
-      tags    : ['bar'] }), client.tcp).then(listener);
-  }
+      tags    : ['bar'] }), client.tcp);
 
+    assert(data.ok);
+  }
 });
 
-test("[promisified client] should send an event with custom attributes as tcp", function(done) {
+test("[promisified client] should send an event with custom attributes as tcp", async function() {
   let counter = 10;
 
-  function listener(data) {
-    assert(data.ok);
-    if (--counter === 0) {
-      setTimeout(done, 100);
-    }
-  };
-
   for (let i = Number(counter); i >= 0; i--) {
-    client.send(client.Event({
+    const data = await client.send(client.Event({
       service : 'hello_tcp_'+i,
       attributes: [{key: "session", value: "123-456-789"},
                    {key: "metric_type", value: "random_number"}
                    ],
       metric  : Math.random(100)*100,
-      tags    : ['bar'] }), client.tcp).then(listener);
+      tags    : ['bar'] }), client.tcp);
+
+    assert(data.ok);
   }
 });
 
-test("[promisified client] should send a state as udp", function(done) {
-  client.send(client.State({
+test("[promisified client] should send a state as udp", async function() {
+  await client.send(client.State({
     service: 'state_udp',
     state: 'ok'
-  }), client.udp).then(done);
+  }), client.udp);
 });
 
-test("[promisified client] should send a state as tcp", function(done) {
+test("[promisified client] should send a state as tcp", async function() {
   let counter = 10;
 
-  function listener(data) {
-    assert(data.ok);
-    if (--counter === 0) {
-      setTimeout(done, 100);
-    }
-  };
-
   for (let i = Number(counter); i >= 0; i--) {
-    client.send(client.State({
+    const data = await client.send(client.State({
       service: 'state_tcp',
       state: 'ok'
-    }), client.tcp).then(listener);
+    }), client.tcp);
+
+    assert(data.ok);
   }
 });
 
-test("[promisified client] should query the server", function(done) {
-  client.send(client.Query({
+test("[promisified client] should query the server", async function() {
+  const data = await client.send(client.Query({
     string: "true"
-  })).then(function(data) {
-    assert(data.ok);
-    assert(Array.isArray(data.events));
-    setTimeout(done, 100);
-  });
+  }));
 
+  assert(data.ok);
+  assert(Array.isArray(data.events));
 });
 
-test("[promisified client] should disconnect from server", function(done) {
-  client.disconnect().then(done);
+test("[promisified client] should disconnect from server", async function() {
+  await client.disconnect();
 });


### PR DESCRIPTION
I was running Riemann under quite a heavy load for some time and promise-based workflow proved well.
Still it had drawbacks such as subscribing to events ('data', 'sent' and 'error') and leaving those handlers in place after promise resolution.
Also this PR is intended to get rid of potential bug which would appear as a resolution of promise with UDP-related event while doing TCP request and vise versa (this is possible when we have many requests using both TCP and UDP transport).